### PR TITLE
TimeSlot 랭킹 조회 API 엔드포인트 추가

### DIFF
--- a/backend/src/main/java/com/bether/bether/timeslot/application/dto/input/TimeSlotRankInput.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/dto/input/TimeSlotRankInput.java
@@ -1,0 +1,12 @@
+package com.bether.bether.timeslot.application.dto.input;
+
+import java.util.UUID;
+
+public record TimeSlotRankInput(
+        UUID roomSession
+) {
+
+    public static TimeSlotRankInput toInput(UUID roomSession) {
+        return new TimeSlotRankInput(roomSession);
+    }
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/application/dto/output/TimeSlotRankOutput.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/dto/output/TimeSlotRankOutput.java
@@ -1,0 +1,11 @@
+package com.bether.bether.timeslot.application.dto.output;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TimeSlotRankOutput(
+        LocalDateTime dateTime,
+        Integer count,
+        List<String> userNames
+) {
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/application/dto/output/TotalTimeSlotRankOutput.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/dto/output/TotalTimeSlotRankOutput.java
@@ -1,0 +1,21 @@
+package com.bether.bether.timeslot.application.dto.output;
+
+import com.bether.bether.timeslot.domain.TotalTimeSlotCount;
+import java.util.List;
+
+public record TotalTimeSlotRankOutput(
+        List<TimeSlotRankOutput> rank
+) {
+
+    public static TotalTimeSlotRankOutput from(TotalTimeSlotCount totalTimeSlotCount) {
+        List<TimeSlotRankOutput> rank = totalTimeSlotCount.getRank()
+                .stream()
+                .map(timeSlotCount -> new TimeSlotRankOutput(
+                        timeSlotCount.getDateTime(),
+                        timeSlotCount.getCount(),
+                        timeSlotCount.getUserNames()
+                ))
+                .toList();
+        return new TotalTimeSlotRankOutput(rank);
+    }
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/application/service/TimeSlotRankService.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/service/TimeSlotRankService.java
@@ -1,0 +1,27 @@
+package com.bether.bether.timeslot.application.service;
+
+import com.bether.bether.timeslot.application.dto.input.TimeSlotRankInput;
+import com.bether.bether.timeslot.application.dto.output.TotalTimeSlotRankOutput;
+import com.bether.bether.timeslot.domain.TimeSlot;
+import com.bether.bether.timeslot.domain.TotalTimeSlotCount;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TimeSlotRankService {
+
+    private final TimeSlotService timeSlotService;
+
+    @Transactional(readOnly = true)
+    public TotalTimeSlotRankOutput calculateRank(final TimeSlotRankInput input) {
+        List<TimeSlot> timeSlots = timeSlotService.getAllByRoomSession(input.roomSession());
+
+        TotalTimeSlotCount timeSlotCount = new TotalTimeSlotCount();
+        timeSlotCount.calculate(timeSlots);
+
+        return TotalTimeSlotRankOutput.from(timeSlotCount);
+    }
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/domain/TimeSlotCount.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/domain/TimeSlotCount.java
@@ -1,0 +1,24 @@
+package com.bether.bether.timeslot.domain;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class TimeSlotCount {
+    private final LocalDateTime dateTime;
+    private Integer count;
+    private final List<String> userNames;
+
+    public TimeSlotCount(LocalDateTime dateTime) {
+        this.dateTime = dateTime;
+        this.count = 0;
+        this.userNames = new ArrayList<>();
+    }
+
+    public void addUserName(String userName) {
+        userNames.add(userName);
+        count++;
+    }
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/domain/TotalTimeSlotCount.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/domain/TotalTimeSlotCount.java
@@ -1,0 +1,40 @@
+package com.bether.bether.timeslot.domain;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class TotalTimeSlotCount {
+
+    private final Map<LocalDateTime, TimeSlotCount> dateTimeCount;
+
+    public TotalTimeSlotCount() {
+        this.dateTimeCount = new HashMap<>();
+    }
+
+    public void calculate(List<TimeSlot> timeSlots) {
+        for (TimeSlot timeSlot : timeSlots) {
+            addTimeSlot(timeSlot);
+        }
+    }
+
+    public List<TimeSlotCount> getRank() {
+        return dateTimeCount.values()
+                .stream()
+                .sorted(Comparator.comparingInt(TimeSlotCount::getCount).reversed())
+                .toList();
+    }
+
+    private void addTimeSlot(TimeSlot timeSlot) {
+        LocalDateTime dateTime = timeSlot.getStartAt();
+        String userName = timeSlot.getUserName();
+
+        dateTimeCount.putIfAbsent(dateTime, new TimeSlotCount(dateTime));
+        dateTimeCount.computeIfPresent(dateTime, ((dateTimeKey, timeSlotCount) -> {
+            timeSlotCount.addUserName(userName);
+            return timeSlotCount;
+        }));
+    }
+}

--- a/backend/src/main/java/com/bether/bether/timeslot/presentation/TimeSlotController.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/presentation/TimeSlotController.java
@@ -1,15 +1,23 @@
 package com.bether.bether.timeslot.presentation;
 
 import com.bether.bether.common.ApiResponse;
+import com.bether.bether.timeslot.application.dto.input.TimeSlotRankInput;
+import com.bether.bether.timeslot.application.dto.output.TotalTimeSlotRankOutput;
+import com.bether.bether.timeslot.application.service.TimeSlotRankService;
 import com.bether.bether.timeslot.application.service.TimeSlotService;
 import com.bether.bether.timeslot.domain.TimeSlot;
 import com.bether.bether.timeslot.presentation.dto.request.TimeSlotCreateRequest;
+import com.bether.bether.timeslot.presentation.dto.response.TotalTimeSlotRankResponse;
 import com.bether.bether.timeslot.presentation.dto.response.TotalTimeSlotResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -17,11 +25,19 @@ import java.util.UUID;
 public class TimeSlotController {
 
     private final TimeSlotService timeSlotService;
+    private final TimeSlotRankService timeSlotRankService;
 
     @GetMapping("/{room-session}")
     public ApiResponse<TotalTimeSlotResponse> get(@PathVariable("room-session") final String roomSession) {
         final List<TimeSlot> timeSlots = timeSlotService.getAllByRoomSession(UUID.fromString(roomSession));
         return ApiResponse.ok(TotalTimeSlotResponse.from(timeSlots));
+    }
+
+    @GetMapping("/{room-session}/rank")
+    public ApiResponse<TotalTimeSlotRankResponse> getRank(@PathVariable("room-session") final String roomSession) {
+        TimeSlotRankInput input = TimeSlotRankInput.toInput(UUID.fromString(roomSession));
+        TotalTimeSlotRankOutput output = timeSlotRankService.calculateRank(input);
+        return ApiResponse.ok(TotalTimeSlotRankResponse.from(output));
     }
 
     @PostMapping

--- a/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/response/TotalTimeSlotRankResponse.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/response/TotalTimeSlotRankResponse.java
@@ -1,0 +1,29 @@
+package com.bether.bether.timeslot.presentation.dto.response;
+
+import com.bether.bether.timeslot.application.dto.output.TotalTimeSlotRankOutput;
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record TotalTimeSlotRankResponse(
+        List<TimeSlotRankResponse> rank
+) {
+
+    private record TimeSlotRankResponse(
+            LocalDateTime dateTime,
+            Integer count,
+            List<String> userNames
+    ) {
+    }
+
+    public static TotalTimeSlotRankResponse from(TotalTimeSlotRankOutput output) {
+        List<TimeSlotRankResponse> rank = output.rank()
+                .stream()
+                .map(rankOutput -> new TimeSlotRankResponse(
+                        rankOutput.dateTime(),
+                        rankOutput.count(),
+                        rankOutput.userNames()
+                ))
+                .toList();
+        return new TotalTimeSlotRankResponse(rank);
+    }
+}

--- a/backend/src/test/java/com/bether/bether/timeslot/application/service/TimeSlotRankServiceTest.java
+++ b/backend/src/test/java/com/bether/bether/timeslot/application/service/TimeSlotRankServiceTest.java
@@ -1,0 +1,72 @@
+package com.bether.bether.timeslot.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bether.bether.timeslot.application.dto.input.TimeSlotRankInput;
+import com.bether.bether.timeslot.application.dto.output.TimeSlotRankOutput;
+import com.bether.bether.timeslot.application.dto.output.TotalTimeSlotRankOutput;
+import com.bether.bether.timeslot.domain.TimeSlot;
+import com.bether.bether.timeslot.domain.TimeSlotRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class TimeSlotRankServiceTest {
+
+    @Autowired
+    private TimeSlotRankService timeSlotRankService;
+
+    @Autowired
+    private TimeSlotRepository timeSlotRepository;
+
+    @DisplayName("타임슬롯 랭킹을 계산한다.")
+    @Test
+    void calculateRank() {
+        // given
+        final UUID roomSession = UUID.randomUUID();
+        final LocalDateTime dateTime1 = LocalDateTime.of(2024, 1, 1, 0, 0);
+        final LocalDateTime dateTime2 = LocalDateTime.of(2024, 3, 1, 2, 30);
+
+        timeSlotRepository.save(TimeSlot.withoutId(roomSession, "user", dateTime1));
+        timeSlotRepository.save(TimeSlot.withoutId(roomSession, "user", dateTime2));
+        timeSlotRepository.save(TimeSlot.withoutId(roomSession, "user2", dateTime1));
+
+        final TimeSlotRankInput input = new TimeSlotRankInput(roomSession);
+
+        // when
+        TotalTimeSlotRankOutput output = timeSlotRankService.calculateRank(input);
+
+        // then
+        assertThat(output.rank())
+                .extracting(TimeSlotRankOutput::dateTime)
+                .containsExactlyElementsOf(List.of(dateTime1, dateTime2));
+    }
+
+    @DisplayName("타임슬롯 리스트에 존재하지 않는 시간은 랭킹에 포함하지 않는다.")
+    @Test
+    void notContainNonExistedTimeSlot() {
+        // given
+        final UUID roomSession = UUID.randomUUID();
+        final LocalDateTime dateTime1 = LocalDateTime.of(2024, 1, 1, 0, 0);
+        final LocalDateTime notContainedDateTime = LocalDateTime.of(2024, 3, 1, 2, 30);
+
+        timeSlotRepository.save(TimeSlot.withoutId(roomSession, "user", dateTime1));
+
+        final TimeSlotRankInput input = new TimeSlotRankInput(roomSession);
+
+        // when
+        TotalTimeSlotRankOutput output = timeSlotRankService.calculateRank(input);
+
+        // then
+        assertThat(output.rank())
+                .extracting(TimeSlotRankOutput::dateTime)
+                .doesNotContain(notContainedDateTime);
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #16

## 📝 작업 내용

> 특정 Session에 저장된 TimeSlot의 개수를 기반으로 하는 랭킹 계산 API 엔드포인트를 추가하였습니다.

### 스크린샷 (선택)
<img width="2559" height="1381" alt="image" src="https://github.com/user-attachments/assets/477e2b85-4f71-4f4d-bf1b-f72deead463b" />

## 💬 리뷰 요구사항(선택)

### List 응답 형식의 Output DTO에서 nested class 사용 관련

처음에 `TotalTimeSlotRankOutput` 를 아래와 같이 구성했었습니다.

```java
public record TotalTimeSlotRankOutput(
        List<TimeSlotRankOutput> rank
) {

    private record TimeSlotRankOutput( // nested class로 구성을 시도함
            LocalDateTime dateTime,
            Integer count,
            List<String> userNames
    ) {
    }
    ...
}
```

그러나, `TotalTimeSlotRankOutput` 을 controller에서 `TotalTimeSlotRankResponse`로 변환할 때, 문제가 발생했었습니다.

```java
public record TotalTimeSlotRankResponse(
        List<TimeSlotRankResponse> rank
) {
    private record TimeSlotRankResponse(...) {}

    public static TotalTimeSlotRankResponse from(TotalTimeSlotRankOutput output) {
        List<TimeSlotRankResponse> rank = output.rank()
                .stream()
                .map(rankOutput -> new TimeSlotRankResponse( // rankOutput이 private라 접근 불가 문제 발생!
                        rankOutput.dateTime(),
                        rankOutput.count(),
                        rankOutput.userNames()
                ))
                .toList();
        return new TotalTimeSlotRankResponse(rank);
    }
}
```

해당 문제를 해결하는 방법으로 "`Output` 은 별도의 class로 구성하는 방법"과 "nested-class 를 `public`으로 열어두는 방법" 2가지를 생각했었고 1번 방법을 적용했습니다.

그 이유는 nested-class를 내부에서 public으로 열면 편하긴 하지만, 추후 프로젝트가 커지면서 어디에 어떤 클래스가 있는지 명확하게 확인하기 어려워질 가능성이 "별도의 파일로 구성되어 있는 것"보다 더 높아질 것 같다는 생각이 들어서였습니다.

해당 방법이 여러분이 보기에 적절한지 또는 해당 문제에 대한 다른 해결 방법이 있을지 궁금합니다!!