### PR TITLE
Discord SlashCommand Registrar/Listener 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -1,38 +1,42 @@
 plugins {
-	id 'java'
-	id 'org.springframework.boot' version '3.5.3'
-	id 'io.spring.dependency-management' version '1.1.7'
+    id 'java'
+    id 'org.springframework.boot' version '3.5.3'
+    id 'io.spring.dependency-management' version '1.1.7'
 }
 
 group = 'com.bether'
 version = '0.0.1-SNAPSHOT'
 
 java {
-	toolchain {
-		languageVersion = JavaLanguageVersion.of(21)
-	}
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
 }
 
 configurations {
-	compileOnly {
-		extendsFrom annotationProcessor
-	}
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
 }
 
 repositories {
-	mavenCentral()
+    mavenCentral()
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    compileOnly 'org.projectlombok:lombok'
+    runtimeOnly 'com.mysql:mysql-connector-j'
+    annotationProcessor 'org.projectlombok:lombok'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    implementation("net.dv8tion:JDA:5.6.1")
+    implementation "org.apache.commons:commons-collections4:4.4" // for jda
+
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }

--- a/backend/src/main/java/com/bether/bether/common/BaseEntity.java
+++ b/backend/src/main/java/com/bether/bether/common/BaseEntity.java
@@ -4,11 +4,10 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
+import java.util.Objects;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.FieldNameConstants;
-
-import java.util.Objects;
 
 @FieldNameConstants
 @NoArgsConstructor
@@ -30,8 +29,12 @@ public abstract class BaseEntity {
     // 프록시 객체도 같은 타입 계열로 간주
     @Override
     public boolean equals(final Object o) {
-        if (this == o) return true;
-        if (!(o instanceof final BaseEntity that)) return false;
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof final BaseEntity that)) {
+            return false;
+        }
         return id != null && id.equals(that.id);
     }
 

--- a/backend/src/main/java/com/bether/bether/discord/application/service/DiscordService.java
+++ b/backend/src/main/java/com/bether/bether/discord/application/service/DiscordService.java
@@ -1,0 +1,20 @@
+package com.bether.bether.discord.application.service;
+
+import lombok.RequiredArgsConstructor;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.entities.channel.concrete.TextChannel;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class DiscordService {
+
+    private final JDA jda;
+
+    public void sendMessage(final String channelId, final String message) {
+        final TextChannel textChannel = jda.getTextChannelById(channelId);
+        if (textChannel != null) {
+            textChannel.sendMessage(message).queue();
+        }
+    }
+}

--- a/backend/src/main/java/com/bether/bether/discord/application/service/DiscordSlashCommandListener.java
+++ b/backend/src/main/java/com/bether/bether/discord/application/service/DiscordSlashCommandListener.java
@@ -1,0 +1,50 @@
+package com.bether.bether.discord.application.service;
+
+import java.util.Objects;
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.events.interaction.command.SlashCommandInteractionEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DiscordSlashCommandListener extends ListenerAdapter {
+
+    @Override
+    public void onSlashCommandInteraction(final SlashCommandInteractionEvent event) {
+        if (!event.getName().equals("schedule")) {
+            return;
+        }
+
+        final String room = Objects.requireNonNull(event.getOption("room_name")).getAsString();
+
+        log.info("""
+                        ========= SlashCommandInteractionEvent =========
+                        name               : {}
+                        guild              : {}
+                        channel            : {}   (id={})
+                        user               : {}
+                        member             : {}
+                        commandString      : {}
+                        fullCommandName    : {}
+                        subcommandGroup    : {}
+                        subcommandName     : {}
+                        raw event          : {}
+                        ==============================================
+                        """,
+                event.getName(),
+                event.getGuild(),
+                event.getChannel(), // TODO channel을 이용해서 room과 연결
+                event.getChannelId(),
+                event.getUser(),
+                event.getMember(),
+                event.getCommandString(),
+                event.getFullCommandName(),
+                event.getSubcommandGroup(),
+                event.getSubcommandName(),
+                event
+        );
+
+        event.reply("🗓️  **" + room + "** 일정 조율해요!").setEphemeral(true).queue();
+    }
+}

--- a/backend/src/main/java/com/bether/bether/discord/application/service/DiscordSlashCommandRegistrar.java
+++ b/backend/src/main/java/com/bether/bether/discord/application/service/DiscordSlashCommandRegistrar.java
@@ -1,0 +1,43 @@
+package com.bether.bether.discord.application.service;
+
+import lombok.extern.slf4j.Slf4j;
+import net.dv8tion.jda.api.entities.Guild;
+import net.dv8tion.jda.api.events.session.ReadyEvent;
+import net.dv8tion.jda.api.hooks.ListenerAdapter;
+import net.dv8tion.jda.api.interactions.commands.OptionType;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class DiscordSlashCommandRegistrar extends ListenerAdapter {
+
+    // 글로벌 설정 (n시간 후 갱신)
+//    @Override
+//    public void onReady(final ReadyEvent event) {
+//        final JDA jda = event.getJDA();
+//        jda.upsertCommand("schedule", "스케줄 방을 생성합니다.")
+//                .addOption(OptionType.STRING, "room_name", "방 이름", true)
+//                .addOption(OptionType.INTEGER, "max_participants", "최대 참여자 수", false)
+//                .queue();
+//
+//        event.getJDA().getGuilds().forEach(g ->
+//                log.info("✔ Bot joined guild: {} / ID={}", g.getName(), g.getId())
+//        );
+//
+//        // 불필요한 추가 등록 방지
+//        jda.removeEventListener(this);
+//    }
+
+    // 특정 길드 설정 (n초 후 갱신)
+    @Override
+    public void onReady(final ReadyEvent e) {
+        final Guild guild = e.getJDA().getGuildById("1393585305713512478");
+        log.info("guild = {}", guild);
+        if (guild != null) {
+            guild.upsertCommand("schedule", "스케줄 방 생성")
+                    .addOption(OptionType.STRING, "room_name", "방 이름", true)
+                    .addOption(OptionType.INTEGER, "max_participants", "최대 참여자 수", false)
+                    .queue();
+        }
+    }
+}

--- a/backend/src/main/java/com/bether/bether/discord/config/DiscordConfig.java
+++ b/backend/src/main/java/com/bether/bether/discord/config/DiscordConfig.java
@@ -1,0 +1,24 @@
+package com.bether.bether.discord.config;
+
+import com.bether.bether.discord.application.service.DiscordSlashCommandListener;
+import com.bether.bether.discord.application.service.DiscordSlashCommandRegistrar;
+import net.dv8tion.jda.api.JDA;
+import net.dv8tion.jda.api.JDABuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DiscordConfig {
+
+    @Bean(destroyMethod = "shutdown")
+    public JDA jda(@Value("${discord.bot.token}") final String token,
+                   final DiscordSlashCommandRegistrar registrar,
+                   final DiscordSlashCommandListener listener) throws Exception {
+        return JDABuilder.createDefault(token)
+                .addEventListeners(listener)
+                .addEventListeners(registrar)
+                .build()
+                .awaitReady();
+    }
+}

--- a/backend/src/main/java/com/bether/bether/room/domain/Room.java
+++ b/backend/src/main/java/com/bether/bether/room/domain/Room.java
@@ -2,12 +2,11 @@ package com.bether.bether.room.domain;
 
 import com.bether.bether.common.BaseEntity;
 import jakarta.persistence.Entity;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import java.util.UUID;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)

--- a/backend/src/main/java/com/bether/bether/timeslot/application/dto/input/TimeSlotInput.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/dto/input/TimeSlotInput.java
@@ -1,7 +1,6 @@
 package com.bether.bether.timeslot.application.dto.input;
 
 import com.bether.bether.timeslot.domain.TimeSlot;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;

--- a/backend/src/main/java/com/bether/bether/timeslot/application/service/TimeSlotService.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/application/service/TimeSlotService.java
@@ -3,12 +3,11 @@ package com.bether.bether.timeslot.application.service;
 import com.bether.bether.timeslot.application.dto.input.TimeSlotInput;
 import com.bether.bether.timeslot.domain.TimeSlot;
 import com.bether.bether.timeslot.domain.TimeSlotRepository;
+import java.util.List;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/bether/bether/timeslot/domain/TimeSlot.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/domain/TimeSlot.java
@@ -2,13 +2,12 @@ package com.bether.bether.timeslot.domain;
 
 import com.bether.bether.common.BaseEntity;
 import jakarta.persistence.Entity;
+import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
-
-import java.time.LocalDateTime;
-import java.util.UUID;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -38,18 +37,24 @@ public class TimeSlot extends BaseEntity {
         return new TimeSlot(roomSession, userName, startAt);
     }
 
-    public static TimeSlot withId(final Long id, final UUID roomSession, final String userName, final LocalDateTime startAt) {
+    public static TimeSlot withId(final Long id,
+                                  final UUID roomSession,
+                                  final String userName,
+                                  final LocalDateTime startAt) {
         validate(id, roomSession, userName, startAt);
         return new TimeSlot(id, roomSession, userName, startAt);
     }
 
-    private static void validate(final Long id, final UUID roomSession, final String userName, final LocalDateTime startAt) {
+    private static void validate(final Long id,
+                                 final UUID roomSession,
+                                 final String userName,
+                                 final LocalDateTime startAt) {
         if (id == null) {
             throw new IllegalArgumentException("id cannot be null");
         }
         validate(roomSession, userName, startAt);
     }
-    
+
     private static void validate(final UUID roomSession, final String userName, final LocalDateTime startAt) {
         if (roomSession == null || userName == null || startAt == null) {
             throw new IllegalArgumentException("roomSession and userName and startAt cannot be null");

--- a/backend/src/main/java/com/bether/bether/timeslot/infrastructure/TimeSlotJpaRepository.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/infrastructure/TimeSlotJpaRepository.java
@@ -1,10 +1,9 @@
 package com.bether.bether.timeslot.infrastructure;
 
 import com.bether.bether.timeslot.domain.TimeSlot;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
 import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TimeSlotJpaRepository extends JpaRepository<TimeSlot, Long> {
 

--- a/backend/src/main/java/com/bether/bether/timeslot/infrastructure/TimeSlotRepositoryImpl.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/infrastructure/TimeSlotRepositoryImpl.java
@@ -2,12 +2,11 @@ package com.bether.bether.timeslot.infrastructure;
 
 import com.bether.bether.timeslot.domain.TimeSlot;
 import com.bether.bether.timeslot.domain.TimeSlotRepository;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Repository;
-
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
 
 @Repository
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/bether/bether/timeslot/presentation/TimeSlotController.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/presentation/TimeSlotController.java
@@ -5,11 +5,15 @@ import com.bether.bether.timeslot.application.service.TimeSlotService;
 import com.bether.bether.timeslot.domain.TimeSlot;
 import com.bether.bether.timeslot.presentation.dto.request.TimeSlotCreateRequest;
 import com.bether.bether.timeslot.presentation.dto.response.TotalTimeSlotResponse;
-import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.*;
-
 import java.util.List;
 import java.util.UUID;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor

--- a/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/request/TimeSlotCreateRequest.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/request/TimeSlotCreateRequest.java
@@ -1,7 +1,6 @@
 package com.bether.bether.timeslot.presentation.dto.request;
 
 import com.bether.bether.timeslot.application.dto.input.TimeSlotInput;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;

--- a/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/response/TotalTimeSlotResponse.java
+++ b/backend/src/main/java/com/bether/bether/timeslot/presentation/dto/response/TotalTimeSlotResponse.java
@@ -1,7 +1,6 @@
 package com.bether.bether.timeslot.presentation.dto.response;
 
 import com.bether.bether.timeslot.domain.TimeSlot;
-
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -9,16 +8,16 @@ public record TotalTimeSlotResponse(
         List<TimeSlotResponse> timeSlots
 ) {
 
-    private record TimeSlotResponse(
-            String userName,
-            LocalDateTime dateTime
-    ) {
-    }
-
     public static TotalTimeSlotResponse from(final List<TimeSlot> timeSlots) {
         return new TotalTimeSlotResponse(timeSlots.stream()
                 .map(timeSlot -> new TimeSlotResponse(timeSlot.getUserName(), timeSlot.getStartAt()))
                 .toList()
         );
+    }
+
+    private record TimeSlotResponse(
+            String userName,
+            LocalDateTime dateTime
+    ) {
     }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -18,3 +18,7 @@ spring:
     properties:
       hibernate:
         format_sql: true
+
+discord:
+  bot:
+    token: ${DISCORD_BOT_TOKEN}

--- a/backend/src/test/java/com/bether/bether/timeslot/application/service/TimeSlotServiceTest.java
+++ b/backend/src/test/java/com/bether/bether/timeslot/application/service/TimeSlotServiceTest.java
@@ -1,19 +1,18 @@
 package com.bether.bether.timeslot.application.service;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.bether.bether.timeslot.application.dto.input.TimeSlotInput;
 import com.bether.bether.timeslot.domain.TimeSlot;
 import com.bether.bether.timeslot.domain.TimeSlotRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.time.LocalDateTime;
-import java.util.List;
-import java.util.UUID;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 @Transactional
@@ -59,7 +58,11 @@ class TimeSlotServiceTest {
     @Test
     void saveAll() {
         // given
-        final TimeSlotInput input = new TimeSlotInput(UUID.randomUUID(), "user", List.of(LocalDateTime.now(), LocalDateTime.now()));
+        final TimeSlotInput input =
+                new TimeSlotInput(
+                        UUID.randomUUID(),
+                        "user",
+                        List.of(LocalDateTime.now(), LocalDateTime.now()));
 
         // when
         final List<TimeSlot> saved = timeSlotService.saveAll(input);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #18 

## 📝 작업 내용

> 추후 discord 연동을 위해 discord bot 설정을 가볍게 진행했습니다!
이외에도 정해둔 컨벤션에 어긋나는 내용을 수정했습니다.

### 스크린샷 (선택)

<img width="1237" height="268" alt="image" src="https://github.com/user-attachments/assets/011c049b-7e1c-421b-92b8-def40bf8ff91" />

<img width="347" height="109" alt="image" src="https://github.com/user-attachments/assets/012d7a73-2e4c-4d56-bdb9-f4674aaefd38" />

<img width="373" height="213" alt="image" src="https://github.com/user-attachments/assets/ab6d5239-2523-43f7-932f-4589382bc023" />


## 💬 리뷰 요구사항(선택)
room 엔티티가 discord/slack에 대한 내용을 알면 discord와 연결되지 않은 room이 nullable 한 필드를 가질 것 같습니다.
따라서 discord/slack 엔티티 측에서 room에 대한 내용을 알아야 할 것 같은데, 어떤 구조가 좋을까요?

<img width="960" height="809" alt="image" src="https://github.com/user-attachments/assets/a6f9c473-2066-4636-85c8-7a0cf13076df" />

[참고 자료](https://github.com/woowacourse/spring-roomescape-payment/pull/323)

아래는 위 자료를 보고 제가 생각한 구조입니다~
```
room                                  -- 방 자체
┌ id             BIGINT   PK
│ title          VARCHAR
│ created_at     TIMESTAMP
│ is_linked      TINYINT  DEFAULT 0   -- (옵션) 하나라도 연결되면 1
└─────────────────────────────────────

room_channel                         -- “Room ↔ 외부 플랫폼” 공통 매핑
┌ id              BIGINT   PK
│ room_id         BIGINT   FK → room.id
│ platform        ENUM('DISCORD','SLACK','TEAMS', …)
│ created_at      TIMESTAMP
└─────────────────────────────────────

discord_channel                      -- 디스코드 세부 정보 (1:1)
┌ id              BIGINT   PK/FK → room_channel.id
│ guild_id        VARCHAR
│ channel_id      VARCHAR
└─────────────────────────────────────

slack_channel                        -- 슬랙 세부 정보 (1:1)
┌ id              BIGINT   PK/FK → room_channel.id
│ team_id         VARCHAR
│ channel_id      VARCHAR
│ webhook_url     VARCHAR
└─────────────────────────────────────
```