### PR TITLE
[FE] Toggle 컴포넌트 추가 

### DIFF
--- a/frontend/src/components/Toggle/Toggle.stories.tsx
+++ b/frontend/src/components/Toggle/Toggle.stories.tsx
@@ -1,0 +1,26 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import Toggle from '.';
+
+const meta: Meta<typeof Toggle> = {
+  title: 'Components/Toggle',
+  component: Toggle,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Toggle>;
+
+export const OnToggle: Story = {
+  args: {
+    isOn: true,
+    onToggle: () => {},
+  },
+};
+
+export const OffToggle: Story = {
+  args: {
+    isOn: false,
+    onToggle: () => {},
+  },
+};

--- a/frontend/src/components/Toggle/Toggle.styled.ts
+++ b/frontend/src/components/Toggle/Toggle.styled.ts
@@ -1,0 +1,27 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.div<{ isOn: boolean }>`
+  position: relative;
+  width: 100%;
+  height: 1.6rem;
+  padding: 0.3rem 0.3rem;
+  background-color: ${({ theme, isOn }) => (isOn ? theme.colors.primary : theme.colors.gray30)};
+  border-radius: 50px;
+  cursor: pointer;
+  overflow: hidden;
+`;
+
+export const Track = styled.div<{ isOn: boolean }>`
+  width: 100%;
+  height: 100%;
+  transition: transform 0.5s ease;
+  transform: ${({ isOn }) => (isOn ? 'translateX(calc(100% - 1.5rem))' : 'translateX(0px)')};
+`;
+
+export const Thumb = styled.div`
+  position: absolute;
+  width: 1.5rem;
+  height: 1.5rem;
+  background-color: #ffffff;
+  border-radius: 100%;
+`;

--- a/frontend/src/components/Toggle/index.tsx
+++ b/frontend/src/components/Toggle/index.tsx
@@ -1,0 +1,18 @@
+import * as S from './Toggle.styled';
+
+interface toggleProps {
+  isOn: boolean;
+  onToggle: () => void;
+}
+
+const Toggle = ({ isOn, onToggle }: toggleProps) => {
+  return (
+    <S.Container onClick={onToggle} isOn={isOn}>
+      <S.Track isOn={isOn}>
+        <S.Thumb />
+      </S.Track>
+    </S.Container>
+  );
+};
+
+export default Toggle;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #40 

## 📝 작업 내용
- Toggle 컴포넌트 생성
- Toggle 컴포넌트 스타일 적용
- Toggle 컴포넌트 스토리북 작성 
> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

### 스크린샷 (선택)
<img width="1112" height="623" alt="image" src="https://github.com/user-attachments/assets/7cdadc7e-7ee7-4231-b1ed-2f506646a506" />

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
- toggle의 width는 100%로 설정해두었습니다.
- 넘겨 받는 props 구조와 네이밍 그리고 전반적인 스타일링 괜찮은지 확인 부탁드려요!

