### PR TITLE
input 컴포넌트 구현

### DIFF
--- a/frontend/src/components/Input/Input.stories.tsx
+++ b/frontend/src/components/Input/Input.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import Input from '.';
+
+const meta: Meta<typeof Input> = {
+  title: 'Components/Input',
+  component: Input,
+  tags: ['autodocs'],
+  argTypes: {
+    isError: {
+      control: 'boolean',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ width: '200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    placeholder: '텍스트를 입력해주세요',
+  },
+};

--- a/frontend/src/components/Input/Input.styled.ts
+++ b/frontend/src/components/Input/Input.styled.ts
@@ -1,0 +1,15 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.input<{ isError?: boolean }>`
+  width: 100%;
+  height: 2rem;
+  border-radius: var(--radius-4);
+  border: 1px solid ${({ theme, isError }) => (isError ? theme.colors.red40 : theme.colors.gray20)};
+  padding: var(--padding-3);
+  background-color: ${({ theme }) => theme.colors.gray10};
+
+  &:focus {
+    outline: none;
+    border: 2px solid ${({ theme }) => theme.colors.plum40};
+  }
+`;

--- a/frontend/src/components/Input/Input.styled.ts
+++ b/frontend/src/components/Input/Input.styled.ts
@@ -10,6 +10,6 @@ export const Container = styled.input<{ isError?: boolean }>`
 
   &:focus {
     outline: none;
-    border: 2px solid ${({ theme }) => theme.colors.plum40};
+    border: 1px solid ${({ theme }) => theme.colors.plum40};
   }
 `;

--- a/frontend/src/components/Input/index.tsx
+++ b/frontend/src/components/Input/index.tsx
@@ -1,0 +1,12 @@
+import { ComponentProps } from 'react';
+import * as S from './Input.styled';
+
+interface InputProps extends ComponentProps<'input'> {
+  isError?: boolean;
+}
+
+const Input = ({ isError = false, ...props }: InputProps) => {
+  return <S.Container isError={isError} {...props} />;
+};
+
+export default Input;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #37 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- [x] input 컴포넌트 구현 및 스토리북 추가
- [x] isError 라는 props를 통해 border 색 변경하여 사용자에게 시각적으로 알림 

### 스크린샷 (선택)

### focus 시 테두리 border 색 변경됨 (기존 웹 디폴트값은 blue..)
<img width="1028" height="557" alt="image" src="https://github.com/user-attachments/assets/15b79bd5-323f-4e4f-bd29-a2285a5e7881" />


### ``isError === true``일 때 border 색 변경 (추후 에러 메시지도 input 하단에 띄울 예정)
<img width="1026" height="527" alt="image" src="https://github.com/user-attachments/assets/e4ed7246-91e7-4b4a-bd96-3420085f16d5" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
