### PR TITLE
DatePicker 컴포넌트 생성

### DIFF
--- a/frontend/src/components/DatePicker/DatePicker.stories.tsx
+++ b/frontend/src/components/DatePicker/DatePicker.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import DatePicker from '.';
+
+const meta: Meta<typeof DatePicker> = {
+  title: 'Components/DatePicker',
+  component: DatePicker,
+  tags: ['autodocs'],
+
+  decorators: [
+    (Story) => (
+      <div style={{ width: '200px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof DatePicker>;
+
+export const DefaultDatePicker: Story = {
+  args: {
+    isError: false,
+  },
+};
+
+export const ErrorDatePicker: Story = {
+  args: {
+    isError: true,
+  },
+};

--- a/frontend/src/components/DatePicker/DatePicker.styled.ts
+++ b/frontend/src/components/DatePicker/DatePicker.styled.ts
@@ -1,0 +1,12 @@
+import styled from '@emotion/styled';
+
+export const Container = styled.input<{ isError: boolean }>`
+  width: 100%;
+  height: 2rem;
+  border-radius: var(--radius-4);
+  border: 1px solid ${({ theme, isError }) => (isError ? theme.colors.red40 : theme.colors.gray20)};
+  padding: var(--padding-3);
+  background-color: ${({ theme }) => theme.colors.gray10};
+  color: ${({ theme }) => theme.colors.gray50};
+  outline: none;
+`;

--- a/frontend/src/components/DatePicker/index.tsx
+++ b/frontend/src/components/DatePicker/index.tsx
@@ -1,0 +1,14 @@
+import { ComponentProps } from 'react';
+import { Container } from './DatePicker.styled';
+
+interface DatePickerProps extends Omit<ComponentProps<'input'>, 'type'> {
+  isError?: boolean;
+}
+
+const DatePicker = ({ isError = false, ...props }: DatePickerProps) => {
+  const date = props.value ?? new Date().toISOString().substring(0, 10);
+
+  return <Container type="date" value={date} isError={isError} {...props} />;
+};
+
+export default DatePicker;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #61 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)
- DatePicker 컴포넌트 생성
- DatePicker 스타일 적용 
- DatePicker 스토리북 작성

## 📁 기타사항
- 일단 지금은 기본 input 태그의 date 타입 사용해서 구현했습니다.
- 기본 placeholder 값은 오늘 날짜가 되도록 설정했습니다.
- 마감기한이 on인데 날짜가 선택되지 않는 오류 상황을 고려해서 isError를 props로 받도록 구현했습니다.
- 전반적인 스타일은 Input 컴포넌트랑 동일하게 설정했습니다.

### 스크린샷 (선택)
<img width="865" height="434" alt="image" src="https://github.com/user-attachments/assets/5491d86b-2c97-4c40-8f01-25c7bd25fa22" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
