### PR TITLE
Fe/feat/timepicker

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -3,6 +3,7 @@ import type { StorybookConfig } from '@storybook/react-webpack5';
 const config: StorybookConfig = {
   stories: ['../src/**/*.mdx', '../src/**/*.stories.@(js|jsx|mjs|ts|tsx)'],
   addons: ['@storybook/addon-webpack5-compiler-swc', '@storybook/addon-docs'],
+  staticDirs: ['../public'],
   framework: {
     name: '@storybook/react-webpack5',
     options: {},

--- a/frontend/public/clock.svg
+++ b/frontend/public/clock.svg
@@ -1,0 +1,11 @@
+<svg width="18" height="18" viewBox="0 0 18 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<g clip-path="url(#clip0_395_24)">
+<path d="M9 16.5C13.1421 16.5 16.5 13.1421 16.5 9C16.5 4.85786 13.1421 1.5 9 1.5C4.85786 1.5 1.5 4.85786 1.5 9C1.5 13.1421 4.85786 16.5 9 16.5Z" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M9 4.5V9L12 10.5" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
+</g>
+<defs>
+<clipPath id="clip0_395_24">
+<rect width="18" height="18" fill="white"/>
+</clipPath>
+</defs>
+</svg>

--- a/frontend/src/components/Timepicker/Timepicker.stories.tsx
+++ b/frontend/src/components/Timepicker/Timepicker.stories.tsx
@@ -1,0 +1,35 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import TimePicker from '.';
+
+const meta: Meta<typeof TimePicker> = {
+  title: 'Components/TimePicker',
+  component: TimePicker,
+  tags: ['autodocs'],
+  args: {
+    defaultValue: '09:00',
+    color: 'gray10',
+  },
+  argTypes: {
+    defaultValue: {
+      control: 'text',
+      description: '기본 시간 값 (예: "09:00")',
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '280px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof TimePicker>;
+
+export const Default: Story = {
+  args: {
+    defaultValue: '09:30',
+  },
+};

--- a/frontend/src/components/Timepicker/Timepicker.stories.tsx
+++ b/frontend/src/components/Timepicker/Timepicker.stories.tsx
@@ -6,7 +6,6 @@ const meta: Meta<typeof TimePicker> = {
   component: TimePicker,
   tags: ['autodocs'],
   args: {
-    defaultValue: '09:00',
     color: 'gray10',
   },
   argTypes: {
@@ -28,8 +27,4 @@ export default meta;
 
 type Story = StoryObj<typeof TimePicker>;
 
-export const Default: Story = {
-  args: {
-    defaultValue: '09:30',
-  },
-};
+export const Default: Story = {};

--- a/frontend/src/components/Timepicker/Timepicker.styled.ts
+++ b/frontend/src/components/Timepicker/Timepicker.styled.ts
@@ -1,0 +1,76 @@
+import { ColorsKey } from '@/styles/theme';
+import styled from '@emotion/styled';
+import { keyframes } from '@emotion/react';
+
+const slideDown = keyframes`
+  from { max-height: 0; opacity: 0; }
+  to { max-height: 200px; opacity: 1; }
+`;
+
+const slideUp = keyframes`
+  from { max-height: 200px; opacity: 1; }
+  to { max-height: 0; opacity: 0; }
+`;
+
+export const Container = styled.div<{ color: ColorsKey }>`
+  width: 100%;
+  height: 2rem;
+  background-color: ${({ theme }) => theme.colors.gray10};
+  border: 1px solid ${({ theme }) => theme.colors.gray20};
+  padding: var(--padding-4) var(--padding-6);
+  border-radius: var(--radius-4);
+  vertical-align: middle;
+  font-family: inherit;
+  display: flex;
+  align-items: center;
+  position: relative;
+`;
+
+export const TimeWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: var(--gap-4);
+`;
+
+export const Wrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  cursor: pointer;
+`;
+
+export const List = styled.ul<{ isOpen: boolean }>`
+  display: flex;
+  flex-direction: row;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  max-height: 200px;
+  overflow-y: auto;
+  background-color: ${({ theme }) => theme.colors.white};
+  border: 1px solid ${({ theme }) => theme.colors.gray20};
+  border-radius: var(--radius-4);
+  box-shadow: var(--shadow-2);
+  animation: ${({ isOpen }) => (isOpen ? slideDown : slideUp)} 0.3s ease-out forwards;
+`;
+export const ListItemWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+`;
+
+export const ListItem = styled.li`
+  cursor: pointer;
+  display: flex;
+  justify-content: center;
+  padding: var(--padding-4);
+  &:hover {
+    background-color: ${({ theme }) => theme.colors.plum30};
+  }
+  &:active {
+    background-color: ${({ theme }) => theme.colors.plum40};
+  }
+  transition: background-color 0.2s ease-in-out;
+`;

--- a/frontend/src/components/Timepicker/index.tsx
+++ b/frontend/src/components/Timepicker/index.tsx
@@ -1,0 +1,69 @@
+import React, { ComponentProps, useState } from 'react';
+import * as S from './Timepicker.styled';
+import { ColorsKey } from '@/styles/theme';
+import Text from '../Text';
+
+interface TimePickerProps extends ComponentProps<'input'> {
+  color: ColorsKey;
+}
+
+const hourOptions = Array.from({ length: 24 }, (_, i) => {
+  const hour = String(i).padStart(2, '0');
+  return hour;
+});
+
+const minuteOptions = ['00', '30'];
+
+const TimePicker = ({ color = 'gray10', ...props }: TimePickerProps) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedHour, setSelectedHour] = useState<string | null>(null);
+  const [selectedMinute, setSelectedMinute] = useState<string | null>(null);
+  const toggleOpen = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const selectHour = (hour: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedHour(hour);
+    setIsOpen(false);
+  };
+
+  const selectMinute = (minute: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedMinute(minute);
+    setIsOpen(false);
+  };
+
+  return (
+    <S.Container role="combobox" color={color} onClick={toggleOpen} {...props}>
+      <S.Wrapper>
+        <S.TimeWrapper>
+          <Text variant="body">{selectedHour || '00'}</Text>
+          <Text variant="body">:</Text>
+          <Text variant="body">{selectedMinute || '00'}</Text>
+        </S.TimeWrapper>
+        <img src="clock.svg" alt="clock icon" />
+      </S.Wrapper>
+      {isOpen && (
+        <S.List role="listbox" isOpen={isOpen}>
+          <S.ListItemWrapper>
+            {hourOptions.map((time) => (
+              <S.ListItem key={time} role="option" onClick={(e) => selectHour(time, e)}>
+                <Text variant="body"> {time}</Text>
+              </S.ListItem>
+            ))}
+          </S.ListItemWrapper>
+          <S.ListItemWrapper>
+            {minuteOptions.map((time) => (
+              <S.ListItem key={time} role="option" onClick={(e) => selectMinute(time, e)}>
+                <Text variant="body"> {time}</Text>
+              </S.ListItem>
+            ))}
+          </S.ListItemWrapper>
+        </S.List>
+      )}
+    </S.Container>
+  );
+};
+
+export default TimePicker;

--- a/frontend/src/components/Timepicker/index.tsx
+++ b/frontend/src/components/Timepicker/index.tsx
@@ -1,7 +1,8 @@
-import React, { ComponentProps, useState } from 'react';
+import { ComponentProps } from 'react';
 import * as S from './Timepicker.styled';
 import { ColorsKey } from '@/styles/theme';
 import Text from '../Text';
+import useTimePicker from '../../hooks/useTimePicker';
 
 interface TimePickerProps extends ComponentProps<'input'> {
   color: ColorsKey;
@@ -15,24 +16,8 @@ const hourOptions = Array.from({ length: 24 }, (_, i) => {
 const minuteOptions = ['00', '30'];
 
 const TimePicker = ({ color = 'gray10', ...props }: TimePickerProps) => {
-  const [isOpen, setIsOpen] = useState(false);
-  const [selectedHour, setSelectedHour] = useState<string | null>(null);
-  const [selectedMinute, setSelectedMinute] = useState<string | null>(null);
-  const toggleOpen = () => {
-    setIsOpen((prev) => !prev);
-  };
-
-  const selectHour = (hour: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setSelectedHour(hour);
-    setIsOpen(false);
-  };
-
-  const selectMinute = (minute: string, e: React.MouseEvent) => {
-    e.stopPropagation();
-    setSelectedMinute(minute);
-    setIsOpen(false);
-  };
+  const { selectedHour, selectedMinute, selectHour, selectMinute, toggleOpen, isOpen } =
+    useTimePicker();
 
   return (
     <S.Container role="combobox" color={color} onClick={toggleOpen} {...props}>

--- a/frontend/src/hooks/useTimePicker.ts
+++ b/frontend/src/hooks/useTimePicker.ts
@@ -1,0 +1,27 @@
+import React, { useState } from 'react';
+
+const useTimePicker = () => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [selectedHour, setSelectedHour] = useState<string | null>(null);
+  const [selectedMinute, setSelectedMinute] = useState<string | null>(null);
+
+  const toggleOpen = () => {
+    setIsOpen((prev) => !prev);
+  };
+
+  const selectHour = (hour: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedHour(hour);
+    setIsOpen(false);
+  };
+
+  const selectMinute = (minute: string, e: React.MouseEvent) => {
+    e.stopPropagation();
+    setSelectedMinute(minute);
+    setIsOpen(false);
+  };
+
+  return { selectedHour, selectedMinute, selectHour, selectMinute, toggleOpen, isOpen };
+};
+
+export default useTimePicker;

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -1,22 +1,21 @@
-import { merge } from "webpack-merge";
-import MiniCssExtractPlugin from "mini-css-extract-plugin";
-import common from "./webpack.common.js";
+import { merge } from 'webpack-merge';
+import common from './webpack.common.js';
 
 export default merge(common, {
-  mode: "development",
-  devtool: "eval-source-map",
+  mode: 'development',
+  devtool: 'eval-source-map',
   // CSS 처리 최적화 - 개발환경에서도 별도 파일로 추출
   module: {
     rules: [
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: ['style-loader', 'css-loader'],
       },
     ],
   },
 
   devServer: {
-    static: "./dist",
+    static: ['./dist', './public'],
     hot: true,
     historyApiFallback: true, // SPA 라우팅
     port: 3000,


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- #41 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- Timepicker 커스텀
    - [x] 분은 30,00분 단위로 분리
    - [x] 시간은 00~23시로 설정
    - [x] 사소한 애니메이션 추가 

### 스크린샷 (선택)

<img width="842" height="414" alt="image" src="https://github.com/user-attachments/assets/86cc55fe-f099-4a78-a100-3712cffca1b0" />


## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

디자인 적으로 00:30 처럼 시간을 통으로 주자니 빈공간이 너무 많아서 우선 시간과 분을 따로 선택하게 두었습니다만 어색하면 말씀해주세요 ~!

## 🔥 전체 논의 사항

현재는 우선 24시간으로 되어있습니다만, 이 부분은 정책적인 부분이라고 생각되어 모든 백엔드분들을 포함하여 올려두었습니다 ! 프론트에서 생각했을 떄는 우선 00시~23시로 24시간 체제가 낫지 않을까 하는 결론이 나왔지만 백엔드와 함께 정책 결정하는게 좋을 것 같아서요 ! 😊 코멘트로 의견 남겨주시면 감사하겠습니다 !

(1) 오전, 오후로 나눠서 1~12시로 한다.
(2) 00~24시로 한다.