### PR TITLE
Storybook 일부 변수 오류

### DIFF
--- a/frontend/.storybook/main.ts
+++ b/frontend/.storybook/main.ts
@@ -9,7 +9,6 @@ const config: StorybookConfig = {
     name: '@storybook/react-webpack5',
     options: {},
   },
-  staticDirs: ['../public'],
 
   webpackFinal: async (baseConfig) => {
     if (baseConfig.resolve) {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -47,7 +47,7 @@
   },
 
   // 타입 검사 대상 소스
-  "include": ["src/**/*"],
+  "include": ["src/**/*", ".storybook/**/*"],
 
   // 검사 대상에서 제외할 디렉터리
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #108 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

.storybook > main.ts에서 path, __dirname 등에서 Caannot find module.. 오류 발생

원인 : .storybook 폴더 내부에 있는 ts 파일의 경우 타입 검사 대상이 되지 않아 오류가 나고 있었음
해결 방법: tsconfig.json에 타입 검사 대상으로 storybook 폴더 추가 

### 스크린샷 (선택)

- 생략
-
## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
