### PR TITLE
크로마틱 워크플로우 수정

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ./frontend/node_modules
-          key: ${{ runner.os }}-yarn-${{ hashFiles('./frontend/yarn.lock') }}
+          key: ${{ runner.os }}-npm-${{ hashFiles('./frontend/package-lock.json') }}
 
-      - run: yarn
+      - run: npm ci
         working-directory: ./frontend
 
       # 내부 리포지토리 PR만 Chromatic 실행


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> closes #110 

## 🔧 수정 내용

Chromatic workflow에서 패키지 매니저 불일치 문제 해결

### 변경 사항
```yaml
# Before
key: ${{ runner.os }}-yarn-${{ hashFiles('./frontend/yarn.lock') }}
- run: yarn

# After  
key: ${{ runner.os }}-npm-${{ hashFiles('./frontend/package-lock.json') }}
- run: npm ci
```

### 🐛 문제점
1. **패키지 매니저 불일치**: 프로젝트는 `npm`을 사용하고 있으나 (package-lock.json 존재), workflow에서는 `yarn` 명령어 사용
2. **존재하지 않는 파일 참조**: 캐시 키에서 `yarn.lock` 파일을 참조하고 있으나, 실제로는 `package-lock.json` 파일만 존재
3. **캐시 미스 발생**: 잘못된 파일 경로로 인해 node_modules 캐시가 제대로 작동하지 않음

### ✅ 해결 방법
- 프로젝트에서 실제 사용하는 `npm`으로 패키지 매니저 통일
- 캐시 키를 실제 존재하는 `package-lock.json`으로 변경
- CI 환경에 최적화된 `npm ci` 명령어 사용 

### 📈 기대 효과
- Chromatic workflow 정상 실행


