### PR TITLE
[BUILD FAIL] [BUILD FAIL] Slack 알림 메시지 전송 기능 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,7 @@ dependencies {
     implementation("net.dv8tion:JDA:5.6.1")
     implementation "org.apache.commons:commons-collections4:4.4" // for jda
 
+    implementation 'com.slack.api:slack-api-client:1.40.0'
     implementation 'org.json:json:20240303'
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,8 +35,8 @@ dependencies {
     implementation("net.dv8tion:JDA:5.6.1")
     implementation "org.apache.commons:commons-collections4:4.4" // for jda
 
-    implementation 'com.slack.api:slack-api-client:1.40.0'
-    implementation 'org.json:json:20240303'
+    implementation 'com.slack.api:slack-api-client:1.45.3'
+    implementation 'org.json:json:20240303' // for JSONObject
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -35,6 +35,8 @@ dependencies {
     implementation("net.dv8tion:JDA:5.6.1")
     implementation "org.apache.commons:commons-collections4:4.4" // for jda
 
+    implementation 'org.json:json:20240303'
+
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
 }
 

--- a/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
+++ b/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
@@ -42,12 +42,14 @@ public class SlackService {
                     .chatPostMessage(request);
 
             if (response.isOk()) {
-                log.info("Slack message sent: channel={}, ts={}", response.getChannel(), response.getTs());
+                log.info("Slack message sent: channel={}", response.getChannel());
             } else {
-                log.warn("Slack API responded with error: {}", response.getError());
+                log.warn("Slack API returned error response: {}", response.getError());
             }
-        } catch (final IOException | SlackApiException e) {
-            log.error("Failed to send Slack message", e);
+        } catch (final SlackApiException e) {
+            log.error("Slack API exception occurred: {}", e.getError(), e);
+        } catch (final IOException e) {
+            log.error("I/O error while sending Slack message", e);
         }
     }
 

--- a/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
+++ b/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
@@ -32,11 +32,11 @@ public class SlackService {
     public void sendMessage(final String message) {
         try {
             final ChatPostMessageRequest request = ChatPostMessageRequest.builder()
-                    .channel(slackProps.getChannelId())
+                    .channel(slackProps.channelId())
                     .text(message)
                     .build();
 
-            final ChatPostMessageResponse response = slack.methods(slackProps.getToken())
+            final ChatPostMessageResponse response = slack.methods(slackProps.token())
                     .chatPostMessage(request);
 
             if (response.isOk()) {
@@ -60,7 +60,7 @@ public class SlackService {
 
         try {
             final String response = slackRestClient.post()
-                    .uri(slackProps.getWebhookUrl())
+                    .uri(slackProps.webhookUrl())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(payload.toString())
                     .retrieve()

--- a/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
+++ b/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
@@ -27,7 +27,7 @@ public class SlackService {
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
     private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-    private final RestClient restClient = RestClient.builder().build();
+    private final RestClient slackRestClient;
     private final Slack slack;
     private final SlackBotProperties slackProps;
 
@@ -59,7 +59,7 @@ public class SlackService {
                 .put("blocks", List.of(blockSection(message)));
 
         try {
-            final String response = restClient.post()
+            final String response = slackRestClient.post()
                     .uri(slackProps.getWebhookUrl())
                     .contentType(MediaType.APPLICATION_JSON)
                     .body(payload.toString())

--- a/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
+++ b/backend/src/main/java/com/bether/bether/slack/application/service/SlackService.java
@@ -1,0 +1,73 @@
+package com.bether.bether.slack.application.service;
+
+import com.bether.bether.slack.application.service.dto.SlackRoomCreatedInput;
+import com.bether.bether.slack.config.SlackBotProperties;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClient;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class SlackService {
+
+    private static final String BASE_SCHEDULE_URL = "https://estime.today/schedule/";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+    private static final DateTimeFormatter TIME_FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+
+    private final RestClient restClient = RestClient.builder().build();
+    private final SlackBotProperties slackProps;
+
+    public void sendRoomCreatedMessage(final SlackRoomCreatedInput input) {
+        final String scheduleLink = BASE_SCHEDULE_URL + input.session();
+        final String message = buildRoomCreatedMessage(input, scheduleLink);
+
+        final JSONObject payload = new JSONObject()
+                .put("blocks", List.of(blockSection(message)));
+
+        try {
+            final String response = restClient.post()
+                    .uri(slackProps.getWebhookUrl())
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .body(payload.toString())
+                    .retrieve()
+                    .body(String.class);
+
+            log.info("Slack message sent for created room: '{}', Link: {}", input.title(), scheduleLink);
+        } catch (final Exception e) {
+            log.error("Failed to send Slack message for created room '{}'. Reason: {}", input.title(), e.getMessage(), e);
+        }
+    }
+
+    private String buildRoomCreatedMessage(final SlackRoomCreatedInput input, final String scheduleLink) {
+        final String dates = input.availableDates().stream()
+                .map(DATE_FORMATTER::format)
+                .collect(Collectors.joining(", "));
+
+        final String start = input.startTime().format(TIME_FORMATTER);
+        final String end = input.endTime().format(TIME_FORMATTER);
+
+        return String.join("\n",
+                "🗓 *일정이 생성되었습니다!*",
+                "> <" + scheduleLink + "|*일정조율 링크바로가기*>",
+                "> 제목 : " + input.title(),
+                "> 날짜 : " + dates,
+                "> 시간 : " + start + " ~ " + end
+        );
+    }
+
+    private JSONObject blockSection(final String text) {
+        return new JSONObject()
+                .put("type", "section")
+                .put("text", new JSONObject()
+                        .put("type", "mrkdwn")
+                        .put("text", text));
+    }
+}

--- a/backend/src/main/java/com/bether/bether/slack/application/service/dto/SlackRoomCreatedInput.java
+++ b/backend/src/main/java/com/bether/bether/slack/application/service/dto/SlackRoomCreatedInput.java
@@ -1,0 +1,27 @@
+package com.bether.bether.slack.application.service.dto;
+
+import com.bether.bether.room.presentation.dto.request.RoomCreateRequest;
+import com.bether.bether.room.presentation.dto.response.RoomCreateResponse;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record SlackRoomCreatedInput(
+        String title,
+        List<LocalDate> availableDates,
+        LocalTime startTime,
+        LocalTime endTime,
+        String session
+) {
+
+    public static SlackRoomCreatedInput from(final RoomCreateRequest request, final RoomCreateResponse response) {
+        return new SlackRoomCreatedInput(
+                request.title(),
+                request.availableDates(),
+                request.startTime(),
+                request.endTime(),
+                response.session()
+        );
+    }
+}

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
@@ -11,5 +11,7 @@ import org.springframework.context.annotation.Configuration;
 @Setter
 public class SlackBotProperties {
 
+    private String token;
+    private String channelId;
     private String webhookUrl;
 }

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
@@ -1,0 +1,15 @@
+package com.bether.bether.slack.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "slack.bot")
+@Getter
+@Setter
+public class SlackBotProperties {
+
+    private String webhookUrl;
+}

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackBotProperties.java
@@ -1,17 +1,11 @@
 package com.bether.bether.slack.config;
 
-import lombok.Getter;
-import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import org.springframework.context.annotation.Configuration;
 
-@Configuration
 @ConfigurationProperties(prefix = "slack.bot")
-@Getter
-@Setter
-public class SlackBotProperties {
-
-    private String token;
-    private String channelId;
-    private String webhookUrl;
+public record SlackBotProperties(
+        String token,
+        String channelId,
+        String webhookUrl
+) {
 }

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
@@ -1,0 +1,14 @@
+package com.bether.bether.slack.config;
+
+import com.slack.api.Slack;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SlackConfig {
+
+    @Bean
+    public Slack slack() {
+        return Slack.getInstance();
+    }
+}

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
@@ -3,9 +3,18 @@ package com.bether.bether.slack.config;
 import com.slack.api.Slack;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestClient;
 
 @Configuration
 public class SlackConfig {
+
+    @Bean
+    public RestClient slackRestClient() {
+        return RestClient.builder()
+                .baseUrl("https://slack.com/api/")
+                .defaultHeader("Content-Type", "application/json")
+                .build();
+    }
 
     @Bean
     public Slack slack() {

--- a/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
+++ b/backend/src/main/java/com/bether/bether/slack/config/SlackConfig.java
@@ -1,10 +1,12 @@
 package com.bether.bether.slack.config;
 
 import com.slack.api.Slack;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
+@EnableConfigurationProperties(SlackBotProperties.class)
 @Configuration
 public class SlackConfig {
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -23,6 +23,10 @@ discord:
   bot:
     token: ${DISCORD_BOT_TOKEN}
 
+slack:
+  bot:
+    webhookUrl: ${SLACK_BOT_WEBHOOK_URL}
+
 springdoc:
   swagger-ui:
     path: /docs

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -25,6 +25,8 @@ discord:
 
 slack:
   bot:
+    token: ${SLACK_BOT_TOKEN}
+    channelId: ${SLACK_BOT_CHANNEL_ID}
     webhookUrl: ${SLACK_BOT_WEBHOOK_URL}
 
 springdoc:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

- close #115 

## 📝 작업 내용

>  Slack Incoming Webhook 사용 알림 메시지 전송 기능 추가
>  Slack SDK 사용 알림 메시지 전송 기능 추가

Slack 알림 메시지 전송 기능을 두 가지 방식으로 구현했습니다. 일정 생성처럼 단순하고 하나의 채널로 전송되는 빠른 단방향 알림은 Incoming Webhook 방식으로 구현했습니다. Slack SDK 방식으로 구현한 부분은 현재 단순한 메시지 전송만 지원하지만 추후에 사용자에게 직접 DM을 보내거나 멘션하는 등, 알림 기능을 확장해 Slack 통합 기능이 필요한 경우를 고려해 추가했습니다.

### 스크린샷 (선택)

<img width="1201" height="222" alt="Screenshot 2025-07-19 at 21 24 56" src="https://github.com/user-attachments/assets/b8e1e4b3-a301-4abd-8597-14abaa4331ee" />

## 💬 리뷰 요구사항(선택)

설정 값들이 application.yml 또는 클래스 내 private 필드로 적절히 분리되어 있는지 확인 부탁드립니다.