### PR TITLE
OptionSettings 컴포넌트 구현

### DIFF
--- a/frontend/src/components/DatePicker/index.tsx
+++ b/frontend/src/components/DatePicker/index.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from 'react';
-import { Container } from './DatePicker.styled';
+import * as S from './DatePicker.styled';
 
 interface DatePickerProps extends Omit<ComponentProps<'input'>, 'type'> {
   isError?: boolean;
@@ -8,7 +8,15 @@ interface DatePickerProps extends Omit<ComponentProps<'input'>, 'type'> {
 const DatePicker = ({ isError = false, ...props }: DatePickerProps) => {
   const date = props.value ?? new Date().toISOString().substring(0, 10);
 
-  return <Container type="date" value={date} isError={isError} {...props} />;
+  return (
+    <S.Container
+      type="date"
+      value={date}
+      onClick={(e) => e.currentTarget.showPicker()}
+      isError={isError}
+      {...props}
+    />
+  );
 };
 
 export default DatePicker;

--- a/frontend/src/components/section/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/section/OptionSettings/OptionSettings.stories.tsx
@@ -1,0 +1,39 @@
+import { Meta, StoryObj } from '@storybook/react-webpack5';
+import { useState } from 'react';
+import OptionSettings from '.';
+
+const meta: Meta<typeof OptionSettings> = {
+  title: 'Components/OptionSettings',
+  component: OptionSettings,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof OptionSettings>;
+
+export const Interactive: Story = {
+  render: () => {
+    const [isOpenAccordion, setIsOpenAccordion] = useState(false);
+    const [isOnDeadline, setIsOnDeadline] = useState(false);
+    const [date, setDate] = useState('2025-07-19');
+
+    return (
+      <OptionSettings
+        isOpenAccordion={isOpenAccordion}
+        onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
+        isOnDeadline={isOnDeadline}
+        onToggleDeadline={() => setIsOnDeadline((prev) => !prev)}
+        date={date}
+        onDateChange={(e) => setDate(e.target.value)}
+      />
+    );
+  },
+};

--- a/frontend/src/components/section/OptionSettings/OptionSettings.stories.tsx
+++ b/frontend/src/components/section/OptionSettings/OptionSettings.stories.tsx
@@ -6,13 +6,6 @@ const meta: Meta<typeof OptionSettings> = {
   title: 'Components/OptionSettings',
   component: OptionSettings,
   tags: ['autodocs'],
-  decorators: [
-    (Story) => (
-      <div>
-        <Story />
-      </div>
-    ),
-  ],
 };
 
 export default meta;
@@ -22,15 +15,15 @@ type Story = StoryObj<typeof OptionSettings>;
 export const Interactive: Story = {
   render: () => {
     const [isOpenAccordion, setIsOpenAccordion] = useState(false);
-    const [isOnDeadline, setIsOnDeadline] = useState(false);
+    const [isDeadlineEnable, setisDeadlineEnable] = useState(false);
     const [date, setDate] = useState('2025-07-19');
 
     return (
       <OptionSettings
         isOpenAccordion={isOpenAccordion}
         onToggleAccordion={() => setIsOpenAccordion((prev) => !prev)}
-        isOnDeadline={isOnDeadline}
-        onToggleDeadline={() => setIsOnDeadline((prev) => !prev)}
+        isDeadlineEnable={isDeadlineEnable}
+        onToggleDeadline={() => setisDeadlineEnable((prev) => !prev)}
         date={date}
         onDateChange={(e) => setDate(e.target.value)}
       />

--- a/frontend/src/components/section/OptionSettings/OptionSettings.styled.ts
+++ b/frontend/src/components/section/OptionSettings/OptionSettings.styled.ts
@@ -1,0 +1,20 @@
+import styled from '@emotion/styled';
+import { CSSProperties } from 'react';
+
+export const Container = styled.div`
+  width: 100%;
+`;
+
+export const Wrapper = styled.div<CSSProperties>`
+  width: 100%;
+
+  display: flex;
+  flex-direction: ${({ flexDirection = 'row' }) => flexDirection};
+  justify-content: ${({ justifyContent = 'start' }) => justifyContent};
+  align-items: ${({ alignItems = 'stretch' }) => alignItems};
+  gap: ${({ gap = '0px' }) => gap};
+
+  padding: ${({ padding = '0' }) => padding};
+  border: ${({ border = 'none' }) => border};
+  border-radius: ${({ borderRadius = '0rem' }) => borderRadius};
+`;

--- a/frontend/src/components/section/OptionSettings/OptionSettings.styled.ts
+++ b/frontend/src/components/section/OptionSettings/OptionSettings.styled.ts
@@ -1,11 +1,11 @@
 import styled from '@emotion/styled';
-import { CSSProperties } from 'react';
+import { StyleProps } from '.';
 
 export const Container = styled.div`
   width: 100%;
 `;
 
-export const Wrapper = styled.div<CSSProperties>`
+export const Wrapper = styled.div<StyleProps>`
   width: 100%;
 
   display: flex;

--- a/frontend/src/components/section/OptionSettings/index.tsx
+++ b/frontend/src/components/section/OptionSettings/index.tsx
@@ -1,0 +1,69 @@
+import * as S from './OptionSettings.styled';
+import Text from '@/components/Text';
+import Toggle from '@/components/Toggle';
+import DatePicker from '@/components/DatePicker';
+import Radio from '@/components/Radio';
+import Accordion from '@/components/Accordian';
+import TimePicker from '@/components/Timepicker';
+import { useTheme } from '@emotion/react';
+import { ACCESS_OPTIONS } from '@/constants/optionsettings';
+
+interface OptionSettingsProps {
+  isOpenAccordion: boolean;
+  onToggleAccordion: () => void;
+  isOnDeadline: boolean;
+  onToggleDeadline: () => void;
+  date: string;
+  onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
+}
+
+const OptionSettings = ({
+  isOpenAccordion,
+  onToggleAccordion,
+  isOnDeadline,
+  onToggleDeadline,
+  date,
+  onDateChange,
+}: OptionSettingsProps) => {
+  const theme = useTheme();
+
+  return (
+    <S.Container>
+      <Accordion title="선택 설정" isOpen={isOpenAccordion} onToggle={onToggleAccordion}>
+        <S.Wrapper flexDirection="column" gap="var(--gap-6)">
+          <S.Wrapper justifyContent="space-between">
+            <Text variant="h3">마감 기한</Text>
+            <Toggle isOn={isOnDeadline} onToggle={onToggleDeadline} />
+          </S.Wrapper>
+          <S.Wrapper gap="var(--gap-2)">
+            <DatePicker value={date} onChange={onDateChange} />
+            <TimePicker />
+          </S.Wrapper>
+        </S.Wrapper>
+        <S.Wrapper flexDirection="column" gap="var(--gap-6)">
+          <Text variant="h3">공개 범위</Text>
+          {ACCESS_OPTIONS.map(({ value, label, Icon, description }) => (
+            <S.Wrapper
+              key={value}
+              border={`1px solid ${theme.colors.gray20}`}
+              padding={'var(--padding-7) var(--padding-4)'}
+              borderRadius={'var(--radius-4)'}
+            >
+              <Radio name="access" value={value}>
+                <S.Wrapper gap="var(--gap-3)" alignItems="center">
+                  <Icon color={theme.colors.text} />
+                  <Text variant="h4">{label}</Text>
+                </S.Wrapper>
+                <Text variant="caption" color="gray50">
+                  {description}
+                </Text>
+              </Radio>
+            </S.Wrapper>
+          ))}
+        </S.Wrapper>
+      </Accordion>
+    </S.Container>
+  );
+};
+
+export default OptionSettings;

--- a/frontend/src/components/section/OptionSettings/index.tsx
+++ b/frontend/src/components/section/OptionSettings/index.tsx
@@ -17,6 +17,16 @@ interface OptionSettingsProps {
   onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
 }
 
+export interface StyleProps {
+  flexDirection?: string;
+  justifyContent?: string;
+  alignItems?: string;
+  gap?: string;
+  border?: string;
+  padding?: string;
+  borderRadius?: string;
+}
+
 const OptionSettings = ({
   isOpenAccordion,
   onToggleAccordion,

--- a/frontend/src/components/section/OptionSettings/index.tsx
+++ b/frontend/src/components/section/OptionSettings/index.tsx
@@ -11,7 +11,7 @@ import { ACCESS_OPTIONS } from '@/constants/optionsettings';
 interface OptionSettingsProps {
   isOpenAccordion: boolean;
   onToggleAccordion: () => void;
-  isOnDeadline: boolean;
+  isDeadlineEnable: boolean;
   onToggleDeadline: () => void;
   date: string;
   onDateChange: (e: React.ChangeEvent<HTMLInputElement>) => void;
@@ -20,7 +20,7 @@ interface OptionSettingsProps {
 const OptionSettings = ({
   isOpenAccordion,
   onToggleAccordion,
-  isOnDeadline,
+  isDeadlineEnable,
   onToggleDeadline,
   date,
   onDateChange,
@@ -33,7 +33,7 @@ const OptionSettings = ({
         <S.Wrapper flexDirection="column" gap="var(--gap-6)">
           <S.Wrapper justifyContent="space-between">
             <Text variant="h3">마감 기한</Text>
-            <Toggle isOn={isOnDeadline} onToggle={onToggleDeadline} />
+            <Toggle isOn={isDeadlineEnable} onToggle={onToggleDeadline} />
           </S.Wrapper>
           <S.Wrapper gap="var(--gap-2)">
             <DatePicker value={date} onChange={onDateChange} />

--- a/frontend/src/constants/optionsettings.tsx
+++ b/frontend/src/constants/optionsettings.tsx
@@ -1,0 +1,17 @@
+import Globe from '@/icons/Globe';
+import Lock from '@/icons/Lock';
+
+export const ACCESS_OPTIONS = [
+  {
+    value: 'public',
+    Icon: Globe,
+    label: '공개',
+    description: '누구나 이 페이지에 접근할 수 있습니다.',
+  },
+  {
+    value: 'private',
+    Icon: Lock,
+    label: '비공개',
+    description: '링크를 가진 사람만 접근할 수 있습니다.',
+  },
+];

--- a/frontend/src/icons/Globe.tsx
+++ b/frontend/src/icons/Globe.tsx
@@ -1,0 +1,44 @@
+const Globe = ({
+  color = '#fff',
+  ...props
+}: {
+  color?: string;
+  props?: React.SVGProps<SVGSVGElement>;
+}) => {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <g xmlns="http://www.w3.org/2000/svg" clipPath="url(#clip0_395_101)">
+        <path
+          d="M9 16.5C13.1421 16.5 16.5 13.1421 16.5 9C16.5 4.85786 13.1421 1.5 9 1.5C4.85786 1.5 1.5 4.85786 1.5 9C1.5 13.1421 4.85786 16.5 9 16.5Z"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M1.5 9H16.5"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+        <path
+          d="M9 1.5C10.876 3.55376 11.9421 6.21903 12 9C11.9421 11.781 10.876 14.4462 9 16.5C7.12404 14.4462 6.05794 11.781 6 9C6.05794 6.21903 7.12404 3.55376 9 1.5Z"
+          stroke={color}
+          strokeWidth="1.5"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      </g>
+    </svg>
+  );
+};
+
+export default Globe;

--- a/frontend/src/icons/Globe.tsx
+++ b/frontend/src/icons/Globe.tsx
@@ -1,10 +1,6 @@
-const Globe = ({
-  color = '#fff',
-  ...props
-}: {
-  color?: string;
-  props?: React.SVGProps<SVGSVGElement>;
-}) => {
+import { IconType } from '@/types/iconType';
+
+const Globe = ({ color = '#fff', ...props }: IconType) => {
   return (
     <svg
       width="18"

--- a/frontend/src/icons/Lock.tsx
+++ b/frontend/src/icons/Lock.tsx
@@ -1,0 +1,35 @@
+const Lock = ({
+  color = '#fff',
+  ...props
+}: {
+  color?: string;
+  props?: React.SVGProps<SVGSVGElement>;
+}) => {
+  return (
+    <svg
+      width="18"
+      height="18"
+      viewBox="0 0 18 18"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      {...props}
+    >
+      <path
+        d="M15 8.25H4.5C3.67157 8.25 3 8.92157 3 9.75V15C3 15.8284 3.67157 16.5 4.5 16.5H15C15.8284 16.5 16.5 15.8284 16.5 15V9.75C16.5 8.92157 15.8284 8.25 15 8.25Z"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M6 8.25V5.25C6 4.25544 6.39509 3.30161 7.09835 2.59835C7.80161 1.89509 8.75544 1.5 9.75 1.5C10.7446 1.5 11.6984 1.89509 12.4017 2.59835C13.1049 3.30161 13.5 4.25544 13.5 5.25V8.25"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+export default Lock;

--- a/frontend/src/icons/Lock.tsx
+++ b/frontend/src/icons/Lock.tsx
@@ -1,10 +1,6 @@
-const Lock = ({
-  color = '#fff',
-  ...props
-}: {
-  color?: string;
-  props?: React.SVGProps<SVGSVGElement>;
-}) => {
+import { IconType } from '@/types/iconType';
+
+const Lock = ({ color = '#fff', ...props }: IconType) => {
   return (
     <svg
       width="18"

--- a/frontend/src/types/iconType.ts
+++ b/frontend/src/types/iconType.ts
@@ -1,0 +1,3 @@
+export interface IconType extends React.SVGProps<SVGSVGElement> {
+  color?: string;
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

[스토리북 링크](https://fe-feat-optionsettings--687852cd7789368357f3bb71.chromatic.com/)

- #88 

## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지 첨부 가능)

- 선택 설정 섹션 컴포넌트 생성
- 지구본, 자물쇠 아이콘 컴포넌트 생성
- 선택 설정 공개/비공개 정보 상수로 분리 
- 선택 설정 섹션 컴포넌트 스타일 적용
- 선택 설정 섹션 컴포넌트 스토리북 작성

### 스크린샷 (선택)

## 💬 리뷰 요구사항(선택)
- 전체적으로 **네이밍** 직관적으로 작성하긴 했는데 괜찮은지 확인 부탁드립니다!

## 기타 전달 사항
- 일단 기본적으로 상태는 외부에서 모두 주입 받는다는 전제로 코드 작성했습니다. 
- Wrapper가 너무 반복적으로 쓰여서 일단 OptionSettings 컴포넌트 파일 내부에 공통 Wrapper를 만들어서 사용하고 있는데 전에 같이 이야기했던 것처럼 공통으로 컴포넌트 분리하면 좋을 것 같다는 생각입니다-!
- Radio 컴포넌트 구성이 동일해서 map으로 돌려서 화면에 그려주도록 코드 작성했습니다. 여기서 사용되는 공개/비공개 정보는 따로 optionsettings.ts 상수 파일을 만들어서 분리하였습니다. 
